### PR TITLE
Add LLM overlay for Hecate

### DIFF
--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -4,6 +4,8 @@ import os
 import requests
 from bs4 import BeautifulSoup
 
+from llm_overlay import llm_reply
+
 os.makedirs("scripts", exist_ok=True)
 
 class Hecate:
@@ -42,6 +44,10 @@ class Hecate:
         elif user_input.startswith("selfupdate:"):
             code_snippet = user_input.split("selfupdate:", 1)[1].strip()
             return self._self_update(code_snippet)
+
+        elif user_input.startswith("ask:"):
+            prompt = user_input.split("ask:", 1)[1].strip()
+            return f"{self.name}: {llm_reply(prompt)}"
 
         elif "code" in user_input.lower() and self.coder:
             return f"{self.name}: What kind of code would you like me to write for you?"

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@
 3. It will commit code into your repo automatically
 
 This is the base of a fully interactive coding bot. Expand with AI core or Discord input.
+
+### LLM Overlay
+
+To enable natural language replies, set the `OPENAI_API_KEY` environment variable and use the `ask:` prefix when talking to the Flask server. Hecate will forward your prompt to the configured LLM and return its response.

--- a/llm_overlay.py
+++ b/llm_overlay.py
@@ -1,0 +1,19 @@
+import os
+import openai
+
+
+def llm_reply(prompt: str, model: str = "gpt-3.5-turbo") -> str:
+    """Return a reply from the specified OpenAI model."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return "OPENAI_API_KEY environment variable not set."
+
+    client = openai.OpenAI(api_key=api_key)
+    try:
+        completion = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return completion.choices[0].message.content.strip()
+    except Exception as exc:
+        return f"LLM error: {exc}"


### PR DESCRIPTION
## Summary
- add `llm_overlay.py` helper using OpenAI
- hook overlay into `hecate.py` with new `ask:` command
- document the overlay in README

## Testing
- `pytest -q`
- `python3 -m py_compile 'OK workspaces/hecate.py' 'llm_overlay.py'`

------
https://chatgpt.com/codex/tasks/task_e_6887423a4270832f98be57bf47ec6c65