### PR TITLE
Add memory retrieval endpoint

### DIFF
--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -114,3 +114,10 @@ class Hecate:
             return f"{self.name}: I've added the provided code to my source file."
         except Exception as e:
             return f"{self.name}: Failed to update myself:\n{e}"
+
+    def get_memory(self):
+        """Return remembered facts as a list of strings."""
+        if not os.path.exists(self.memory_file):
+            return []
+        with open(self.memory_file, "r") as f:
+            return [line.strip() for line in f if line.strip()]

--- a/OK workspaces/main. py
+++ b/OK workspaces/main. py
@@ -15,5 +15,11 @@ def talk():
     response = hecate.respond(user_input)
     return jsonify({"reply": response})
 
+
+@app.route("/memory", methods=["GET"])
+def memory():
+    """Return Hecate's stored facts."""
+    return jsonify({"memory": hecate.get_memory()})
+
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8080)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This simple project exposes a small voice assistant named **Hecate**. The
 assistant can remember short facts, load and run code snippets and even modify
 her own source file.
 
+### Flask API
+
+Run `python OK\ workspaces/main.\ py` and use `/talk` to chat with Hecate.
+You can now retrieve remembered facts via a `GET /memory` request.
+
 ### Self update
 
 Send a message starting with `selfupdate:` followed by Python code and Hecate

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 <body style="font-family: sans-serif; padding: 2em;">
   <h1>🕯️ Talk to Hecate</h1>
   <button onclick="startListening()">🎤 Speak</button>
+  <button onclick="showMemory()">📜 Memories</button>
   <p id="transcript"></p>
   <p><strong>Hecate:</strong> <span id="response"></span></p>
 
@@ -43,6 +44,12 @@
       msg.text = text;
       msg.lang = "en-US";
       window.speechSynthesis.speak(msg);
+    }
+
+    async function showMemory() {
+      const res = await fetch("http://localhost:8080/memory");
+      const data = await res.json();
+      alert(data.memory.join("\n") || "(no memories)");
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- expose stored memory via GET `/memory`
- provide helper `get_memory()` in `hecate.py`
- add memories button in the UI
- document the new API route

## Testing
- `python -m py_compile 'OK workspaces/hecate.py' 'OK workspaces/main. py'`

------
https://chatgpt.com/codex/tasks/task_e_687238fff6bc832f9d34949996c87f2c