### PR TITLE
Improve typed input handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,17 @@ her own source file.
 
 Send a message starting with `selfupdate:` followed by Python code and Hecate
 will append that snippet to `hecate.py`.
+
+### Mobile access
+
+To use Hecate from another device like an iPhone, run the Flask app so it
+listens on your machine's IP address:
+
+```bash
+python "OK workspaces/main. py"
+```
+
+Then open `http://<your-ip>:8080/index.html` in Safari. The page now sends
+requests to `/talk` on the same host, so it works across the network. If the
+browser lacks speech recognition, it will prompt you to type your request
+instead.

--- a/index.html
+++ b/index.html
@@ -11,24 +11,24 @@
 
   <script>
     function startListening() {
-      const recognition = new (window.SpeechRecognition || window.webkitSpeechRecognition)();
+      const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+      if (!SpeechRecognition) {
+        const text = prompt("Speech recognition unsupported. Type your request:");
+        if (text) {
+          document.getElementById("transcript").innerText = `You: ${text}`;
+          sendMessage(text);
+        }
+        return;
+      }
+      const recognition = new SpeechRecognition();
       recognition.lang = 'en-US';
       recognition.interimResults = false;
 
-      recognition.onresult = async function(event) {
+      recognition.onresult = function(event) {
         const text = event.results[0][0].transcript;
         document.getElementById("transcript").innerText = `You: ${text}`;
 
-        const res = await fetch("http://localhost:8080/talk", {
-          method: "POST",
-          headers: {"Content-Type": "application/json"},
-          body: JSON.stringify({ message: text })
-        });
-
-        const data = await res.json();
-        const reply = data.reply;
-        document.getElementById("response").innerText = reply;
-        speak(reply);
+        sendMessage(text);
       };
 
       recognition.onerror = function(err) {
@@ -36,6 +36,20 @@
       };
 
       recognition.start();
+    }
+
+    function sendMessage(text) {
+      fetch("/talk", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({ message: text })
+      })
+      .then(res => res.json())
+      .then(data => {
+        const reply = data.reply;
+        document.getElementById("response").innerText = reply;
+        speak(reply);
+      });
     }
 
     function speak(text) {


### PR DESCRIPTION
## Summary
- show typed requests in transcript when speech recognition isn't available

## Testing
- `python -m py_compile 'OK workspaces/main. py' 'OK workspaces/hecate.py'`


------
https://chatgpt.com/codex/tasks/task_e_687237ffea78832fad3dd05a99587097