### PR TITLE
Add voice selection to Hecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ python "OK workspaces/main.py"
 ```
 
 In the browser interface, type your message into the text box or use the voice button.
+Choose a voice from the dropdown to hear Hecate reply aloud.
 You can also click **Summarize Memory** to get a short summary of all remembered facts.
 
 ### Run Locally

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
 <body>
   <h1>🕯️ Talk to Hecate</h1>
   <button onclick="startListening()">🎤 Speak</button>
+  <select id="voiceSelect"></select>
   <input type="text" id="textInput" placeholder="Type your message"/>
   <button onclick="sendText()">Send</button>
   <p id="transcript"></p>
@@ -62,8 +63,28 @@
     const msg = new SpeechSynthesisUtterance();
     msg.text = text;
     msg.lang = "en-US";
+    const voiceName = document.getElementById("voiceSelect").value;
+    const voice = window.speechSynthesis.getVoices().find(v => v.name === voiceName);
+    if (voice) msg.voice = voice;
     window.speechSynthesis.speak(msg);
   }
+
+  function populateVoices() {
+    const select = document.getElementById("voiceSelect");
+    const voices = window.speechSynthesis.getVoices();
+    select.innerHTML = "";
+    voices.forEach(v => {
+      const opt = document.createElement("option");
+      opt.value = v.name;
+      opt.textContent = v.name;
+      select.appendChild(opt);
+    });
+    const preferred = voices.find(v => /hecate/i.test(v.name)) || voices.find(v => /female/i.test(v.name));
+    if (preferred) select.value = preferred.name;
+  }
+
+  window.speechSynthesis.onvoiceschanged = populateVoices;
+  populateVoices();
 
   let currentLocation = null;
   function getLocation() {


### PR DESCRIPTION
## Summary
- expose a dropdown of available voices in the browser UI
- use the selected voice when speaking replies
- note the voice dropdown in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node -c hecate-auto.js`


------
https://chatgpt.com/codex/tasks/task_e_6887be251418832f86ed2ad4b03592ec