### PR TITLE
Implement autonomous connective learning

### DIFF
--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -221,6 +221,11 @@ class Hecate:
     def _remember_fact(self, fact):
         with open(self.memory_file, "a") as f:
             f.write(fact + "\n")
+        try:
+            with open(self.shared_memory_file, "a") as f:
+                f.write(f"{self.clone_id}: {fact}\n")
+        except Exception:
+            pass
         return f"{self.name}: Got it. I’ll remember that."
 
     def _recall_facts(self):
@@ -268,7 +273,12 @@ class Hecate:
             summary = resp.choices[0].message["content"].strip()
             with open(self.memory_file, "a") as f:
                 f.write(summary + "\n")
-            return f"{self.name}: I've noted the key points."
+            try:
+                with open(self.shared_memory_file, "a") as f:
+                    f.write(summary + "\n")
+            except Exception:
+                pass
+            return f"{self.name}: I've noted the key points and shared them."
         except Exception as e:
             return f"{self.name}: Failed to learn from text:\n{e}"
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@
 This is the base of a fully interactive coding bot. Expand with AI core or Discord input.
 
 ### Memory Tools
-Use `remember:your fact` to store a memory and `recall` to read them back. The command `summarize` or the **Summarize Memory** button in the browser returns a short summary of everything remembered.
-Use `learn:some text` to extract key bullet points from the provided content and append them to memory.
+Use `remember:your fact` to store a memory and `recall` to read them back. The command `summarize` or the **Summarize Memory** button in the browser returns a short summary of everything remembered. Facts that you remember are automatically written to the shared clone memory so each instance keeps the same notes.
+Use `learn:some text` to extract key bullet points from the provided content and append them to memory. These key points are also propagated to the shared memory automatically.
 Use `clone:send:message` to broadcast a message to other running clones. They can read all messages with `clone:read`.
 Use `clone:remember:fact` to store a note in a shared memory file that all clones access. Retrieve the combined notes with `clone:memories`.
+This seamless sharing of notes and lessons creates an autonomous connective learning network across every clone.
 
 ### ChatGPT Integration
 Hecate can now send your text prompts to OpenAI's ChatGPT. By default it uses


### PR DESCRIPTION
## Summary
- automatically write remembered facts to clone-wide memory
- automatically share bullet-point summaries from `learn:` across clones
- document the new behaviour in the Memory Tools section of README

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`
- `node --check ai_core.js`
- `node --check hecate-auto.js`


------
https://chatgpt.com/codex/tasks/task_e_6887cacb3768832f83c6b0fd786fb115