### PR TITLE
Add keyword usage DB storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,5 +169,16 @@ Use `selfrepair:description` to attempt an automated fix of Hecate's own code ba
 Run `antivirus.py` to periodically scan the `scripts/` directory for infected files using `clamscan`. The script also attempts to keep the ClamAV virus definitions up to date by calling `freshclam` at regular intervals. Any detected threats are moved to the `quarantine/` folder. Ensure both `clamscan` and `freshclam` are installed so the scan and updates can run successfully.
 
 ### MandemOS Database
-Run `python setup_database.py` to create a SQLite database named `mandemos.db` with tables for scrolls, relics, and keys.
+Run `python setup_database.py` to create a SQLite database named `mandemos.db` with tables for scrolls, relics, keys, and keyword usage statistics.
+
+After running the clone network, you can capture the current keyword usage by
+executing:
+
+```bash
+python keyword_stats_to_db.py
+```
+
+This script queries the `/keywords` endpoint of the clone network (controlled by
+`CLONE_SERVER_URL`) and updates the `keyword_usage` table with the latest counts.
+If the network cannot be reached, the script simply prints an error and exits without modifying the database.
 

--- a/keyword_stats_to_db.py
+++ b/keyword_stats_to_db.py
@@ -1,0 +1,57 @@
+import os
+import sqlite3
+import requests
+
+DB_NAME = 'mandemos.db'
+SERVER_URL = os.getenv('CLONE_SERVER_URL', 'http://localhost:5000')
+
+
+def init_db():
+    """Ensure the keyword_usage table exists and return connection."""
+    conn = sqlite3.connect(DB_NAME)
+    cur = conn.cursor()
+    cur.execute(
+        '''CREATE TABLE IF NOT EXISTS keyword_usage (
+            clone_id TEXT,
+            keyword TEXT,
+            count INTEGER,
+            PRIMARY KEY (clone_id, keyword)
+        )'''
+    )
+    conn.commit()
+    return conn
+
+
+def fetch_keyword_stats():
+    """Retrieve keyword usage stats from the clone network server."""
+    try:
+        resp = requests.get(f"{SERVER_URL}/keywords", timeout=5)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as exc:
+        print(f"Failed to fetch keyword stats: {exc}")
+        return {}
+
+
+def store_stats(conn, stats):
+    cur = conn.cursor()
+    for clone_id, keywords in stats.items():
+        for kw, count in keywords.items():
+            cur.execute(
+                'INSERT OR REPLACE INTO keyword_usage (clone_id, keyword, count) VALUES (?, ?, ?)',
+                (clone_id, kw, count)
+            )
+    conn.commit()
+
+
+def main():
+    conn = init_db()
+    stats = fetch_keyword_stats()
+    if stats:
+        store_stats(conn, stats)
+        print('Keyword usage stored to database')
+    conn.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/setup_database.py
+++ b/setup_database.py
@@ -7,7 +7,8 @@ DB_NAME = 'mandemos.db'
 TABLES = {
     'scrolls': 'CREATE TABLE IF NOT EXISTS scrolls (id INTEGER PRIMARY KEY, name TEXT, description TEXT)',
     'relics': 'CREATE TABLE IF NOT EXISTS relics (id INTEGER PRIMARY KEY, name TEXT, origin TEXT)',
-    'keys': 'CREATE TABLE IF NOT EXISTS keys (id INTEGER PRIMARY KEY, name TEXT, purpose TEXT)'
+    'keys': 'CREATE TABLE IF NOT EXISTS keys (id INTEGER PRIMARY KEY, name TEXT, purpose TEXT)',
+    'keyword_usage': 'CREATE TABLE IF NOT EXISTS keyword_usage (clone_id TEXT, keyword TEXT, count INTEGER, PRIMARY KEY (clone_id, keyword))'
 }
 
 def setup_database():


### PR DESCRIPTION
## Summary
- extend database setup with `keyword_usage` table
- add `keyword_stats_to_db.py` to record keyword usage from the clone network
- document keyword usage tracking in README
- handle unreachable clone network gracefully

## Testing
- `python -m py_compile keyword_stats_to_db.py setup_database.py`
- `python setup_database.py`
- `python keyword_stats_to_db.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6887d374e5ac832fadbd47018a6c4f8b